### PR TITLE
Fix stuck uploading state

### DIFF
--- a/components/recorder.tsx
+++ b/components/recorder.tsx
@@ -300,6 +300,7 @@ export default function Recorder({ assignmentId, studentId, dueDate, onRecitatio
     } catch (err: any) {
       console.error("Error submitting recitation:", err)
       setError(err.message || "Failed to submit recitation")
+    } finally {
       setIsUploading(false)
     }
   }


### PR DESCRIPTION
## Summary
- ensure recorder resets `isUploading` flag after submission

## Testing
- `npm run build`
- `npm run lint` *(fails: prompts for ESLint config)*

------
https://chatgpt.com/codex/tasks/task_e_684091de5c188329b431b9569f43896b